### PR TITLE
添加51cto网站和categories支持

### DIFF
--- a/src/markdown.js
+++ b/src/markdown.js
@@ -103,6 +103,13 @@ export const formatMarkdownBody = (container, selectors, options, exec) => {
         })
         options.context.tag = tag
     }
+    if (selectors.categories) {
+        const categories = []
+        queryAll(selectors.categories).map(item => {
+            categories.push(item.innerText.replace(/(^[\n\s]+|[\n\s]+$)/g, ''))
+        })
+        options.context.categories = categories
+    }
     if (options.link) {
         queryAll('a', markdownBody).map(item => item.href = item.title)
     }
@@ -147,6 +154,7 @@ const extract = async ({ markdownBody, selectors, options, exec, hook }) => {
         author: getText(selectors.userName),
         home: getUrl(location.origin, getAttribute('href', selectors.userLink)),
         tag: context.tag,
+        categories: context.categories,
         description: markdownBody.innerText.replace(/^([\n\s]+)/g, '').replace(/\n/g, ' ').slice(0, 50) + '...',
     }, localOptions.tpl)
     const markdownDoc = html2markdown(info + getMarkdown(markdownBody), {})

--- a/src/websites/51CTO.js
+++ b/src/websites/51CTO.js
@@ -1,0 +1,28 @@
+export const hosts = ['blog.51cto.com']
+
+export const options = {
+    origin: '51cto',
+    link: false,
+    br: true,
+    code: false,
+    selectors: {
+        title: '.title',
+        body: '.editor-preview-side',
+        copyBtn: '.copy-btn',
+        userName: '.username .blog-user',
+        userLink: '.username',
+        invalid: '',
+        unpack: '',
+        tag: '.mess-tag .shence_tag'
+    }
+}
+
+export const hook = {}
+
+export const config = {
+    hosts,
+    options,
+    hook
+}
+
+export default config

--- a/src/websites/51CTO.js
+++ b/src/websites/51CTO.js
@@ -10,10 +10,11 @@ export const options = {
         body: '.editor-preview-side',
         copyBtn: '.copy-btn',
         userName: '.username .blog-user',
-        userLink: '.username',
+        userLink: '.avatar-img',
         invalid: '',
         unpack: '',
-        tag: '.mess-tag .shence_tag'
+        tag: '.mess-tag .shence_tag',
+        categories: '.mess-tag .shence_cate'
     }
 }
 


### PR DESCRIPTION
为51cto设置了基本属性，并在51cto的markdown文档上支持识别文章的categories。